### PR TITLE
Downgraded from solidity 0.8.20 to 0.8.19 to avoid confusion with Sha…

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -4,6 +4,6 @@
     "rules": {
       "max-line-length": ["off", 120],
       "prettier/prettier": "error",
-      "compiler-version": ["error","^0.8.20"]
+      "compiler-version": ["error","^0.8.19"]
     }
   }

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ import "@wraith-works/contracts/tokens/ERC721/BaseERC721.sol";
 ### Example Contract
 
 ```solidity
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.19;
 
 import "@wraith-works/contracts/tokens/ERC721/AirdropERC721.sol";
 import "@wraith-works/contracts/tokens/ERC721/RevealableERC721.sol";
@@ -86,7 +86,7 @@ BaseERC721 revealable contract test
   ✓ tokenURI returns URI for token when revealed
 
 ·--------------------------------------------|---------------------------|-------------|-----------------------------·
-|            Solc version: 0.8.20            ·  Optimizer enabled: true  ·  Runs: 200  ·  Block limit: 10000000 gas  │
+|            Solc version: 0.8.19            ·  Optimizer enabled: true  ·  Runs: 200  ·  Block limit: 10000000 gas  │
 ·············································|···························|·············|······························
 |  Methods                                   ·              175 gwei/gas               ·       0.84 usd/matic        │
 ·························|···················|·············|·············|·············|···············|··············

--- a/contracts/mocks/AirdropERC721Mock.sol
+++ b/contracts/mocks/AirdropERC721Mock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.19;
 
 import "../tokens/ERC721/AirdropERC721.sol";
 

--- a/contracts/mocks/ERC20Mock.sol
+++ b/contracts/mocks/ERC20Mock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.19;
 
 import "../tokens/ERC20/BaseERC20.sol";
 

--- a/contracts/mocks/ERC721Mock.sol
+++ b/contracts/mocks/ERC721Mock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.19;
 
 import "../tokens/ERC721/BaseERC721.sol";
 

--- a/contracts/mocks/RevealableERC721Mock.sol
+++ b/contracts/mocks/RevealableERC721Mock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.19;
 
 import "../tokens/ERC721/RevealableERC721.sol";
 

--- a/contracts/tokens/ERC20/BaseERC20.sol
+++ b/contracts/tokens/ERC20/BaseERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.19;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/security/Pausable.sol";

--- a/contracts/tokens/ERC20/IBaseERC20.sol
+++ b/contracts/tokens/ERC20/IBaseERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.19;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/tokens/ERC721/AirdropERC721.sol
+++ b/contracts/tokens/ERC721/AirdropERC721.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.19;
 
 import "./BaseERC721.sol";
 

--- a/contracts/tokens/ERC721/BaseERC721.sol
+++ b/contracts/tokens/ERC721/BaseERC721.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.19;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/security/Pausable.sol";

--- a/contracts/tokens/ERC721/RevealableERC721.sol
+++ b/contracts/tokens/ERC721/RevealableERC721.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.19;
 
 import "./BaseERC721.sol";
 

--- a/docs/tokens/ERC20/BaseERC20.md
+++ b/docs/tokens/ERC20/BaseERC20.md
@@ -4,7 +4,7 @@ import "@wraith-works/contracts/tokens/ERC20/BaseERC20.sol";
 
 The `BaseERC20` contract extends the basic `ERC20` contract with ownership and pausability capabilities.
 
-[View Contract :fontawesome-brands-github:](https://github.com/Wraith-Works/wraith-works-contracts/blob/v0.2.1-beta/contracts/tokens/ERC20/Base20.sol){ .md-button target="_blank" }
+[View Contract :fontawesome-brands-github:](https://github.com/Wraith-Works/wraith-works-contracts/blob/main/contracts/tokens/ERC20/Base20.sol){ .md-button target="_blank" }
 
 ## Implementation
 
@@ -52,7 +52,7 @@ The `BaseERC20` contract requires the following variables to be passed into the 
 ## Example
 
 ```solidity
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.19;
 
 import "@wraith-works/contracts/tokens/ERC20/BaseERC20.sol";
 

--- a/docs/tokens/ERC721/AirdropERC721.md
+++ b/docs/tokens/ERC721/AirdropERC721.md
@@ -4,7 +4,7 @@ import "@wraith-works/contracts/tokens/ERC721/AirdropERC721.sol";
 
 The `AirdropERC721` contract provides airdrop functionality to the [BaseERC721](/tokens/ERC721/BaseERC721) contract.
 
-[View Contract :fontawesome-brands-github:](https://github.com/Wraith-Works/wraith-works-contracts/blob/v0.2.0-beta/contracts/tokens/ERC721/AirdropERC721.sol){ .md-button target="_blank" }
+[View Contract :fontawesome-brands-github:](https://github.com/Wraith-Works/wraith-works-contracts/blob/main/contracts/tokens/ERC721/AirdropERC721.sol){ .md-button target="_blank" }
 
 ## Implementation
 
@@ -28,7 +28,7 @@ The `AirdropERC721` contract does not have any additional requirements except wh
 ## Example
 
 ```solidity
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.19;
 
 import "@wraith-works/contracts/tokens/ERC721/AirdropERC721.sol";
 

--- a/docs/tokens/ERC721/BaseERC721.md
+++ b/docs/tokens/ERC721/BaseERC721.md
@@ -4,7 +4,7 @@ import "@wraith-works/contracts/tokens/ERC721/BaseERC721.sol";
 
 The `BaseERC721` contract extends the basic `ERC721` contract with various extensions for controlling a max mint supply and setting royalities.
 
-[View Contract :fontawesome-brands-github:](https://github.com/Wraith-Works/wraith-works-contracts/blob/v0.2.0-beta/contracts/tokens/ERC721/BaseERC721.sol){ .md-button target="_blank" }
+[View Contract :fontawesome-brands-github:](https://github.com/Wraith-Works/wraith-works-contracts/blob/main/contracts/tokens/ERC721/BaseERC721.sol){ .md-button target="_blank" }
 
 ## Implementation
 
@@ -100,7 +100,7 @@ The `BaseERC721` contract requires the following variables to be passed into the
 ## Example
 
 ```solidity
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.19;
 
 import "@wraith-works/contracts/tokens/ERC721/BaseERC721.sol";
 

--- a/docs/tokens/ERC721/RevealableERC721.md
+++ b/docs/tokens/ERC721/RevealableERC721.md
@@ -4,7 +4,7 @@ import "@wraith-works/contracts/tokens/ERC721/RevealableERC721.sol";
 
 The `RevealableERC721` contract provides reveal functionality to the [BaseERC721](/tokens/ERC721/BaseERC721) contract.
 
-[View Contract :fontawesome-brands-github:](https://github.com/Wraith-Works/wraith-works-contracts/blob/v0.2.0-beta/contracts/tokens/ERC721/RevealableERC721.sol){ .md-button target="_blank" }
+[View Contract :fontawesome-brands-github:](https://github.com/Wraith-Works/wraith-works-contracts/blob/main/contracts/tokens/ERC721/RevealableERC721.sol){ .md-button target="_blank" }
 
 ## Implementation
 
@@ -47,7 +47,7 @@ The `RevealableERC721` contract requires the following variables to be passed in
 ## Example
 
 ```solidity
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.19;
 
 import "@wraith-works/contracts/tokens/ERC721/RevealableERC721.sol";
 

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -29,7 +29,7 @@ const config = {
     solidity: {
         compilers: [
             {
-                version: '0.8.20',
+                version: '0.8.19',
                 settings: {
                     optimizer: {
                         enabled: true,


### PR DESCRIPTION
Solidity 0.8.20 will try to compile for the Shanghai hardfork, which networks like Polygon have yet to implement. Compiling to deploy on Polygon will result in an error message, and the developer will have to force the evmVersion to be something other than shanghai. This PR downgrades to 0.8.19